### PR TITLE
added retry decorator on the cassandra session

### DIFF
--- a/fastapi-app/api_config/db.py
+++ b/fastapi-app/api_config/db.py
@@ -1,7 +1,8 @@
 #Author: Adrian J 2022-05
-from cassandra.cluster import Cluster, ExecutionProfile
+from cassandra.cluster import Cluster, ExecutionProfile, NoHostAvailable
 from cassandra.auth import PlainTextAuthProvider
 from cassandra.cqlengine.connection import register_connection, set_default_connection
+from tenacity import retry, stop_after_attempt, retry_if_exception_type, wait_fixed
 
 from . import config #TO-DO structure project better
 
@@ -13,13 +14,17 @@ CASSANDRA_DB_PASSWORD = settings.cass_db_password
 CASSANDRA_DB_PORT = settings.cass_db_port
 CASSANDRA_DB_KEYSPACE = settings.cass_db_keyspace
 
+#retry used as patch to handle exception on host not available for the delay on the cassandra
+#container to build TO-DO find the correct way to handle using cassandra driver. 
+#risk put stress on the cluster
 
 def get_cluster_conn():
     auth_provider = PlainTextAuthProvider(username=CASSANDRA_DB_DB_USERNAME, password=CASSANDRA_DB_PASSWORD)
     profile_long = ExecutionProfile(request_timeout=30)
     cluster = Cluster([CASSANDRA_DB_CLIENT_ID], port=CASSANDRA_DB_PORT, auth_provider=auth_provider, execution_profiles={'long': profile_long})
     return cluster
-
+    
+@retry(stop=stop_after_attempt(3), wait=wait_fixed(30), retry=retry_if_exception_type(NoHostAvailable))
 def get_session():
     cluster = get_cluster_conn()
     session = cluster.connect(CASSANDRA_DB_KEYSPACE)

--- a/fastapi-app/requirements.txt
+++ b/fastapi-app/requirements.txt
@@ -2,5 +2,6 @@ cassandra-driver==3.25.0
 fastapi==0.75.2
 pydantic==1.9.0
 pytest==7.1.2
-uvicorn==0.17.6
 python-dotenv==0.20.0
+tenacity==8.0.1
+uvicorn==0.17.6


### PR DESCRIPTION
patch for the method that calls the cassandra connection to retry and wait for the cassandra cluster to be up and running otherwise host no available error raised. THIS IS NOT A PRODUCTION PATCH